### PR TITLE
fix: Exclude debug and log files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,10 @@ screenshot.png
 *.zip
 test.py
 input.py
+
+# Exclude debug and log files
+debug_log.txt
+drop.txt
+drops.txt
+*log*
+*.bak


### PR DESCRIPTION
Fix to this issue:
https://github.com/lucaslafere/TLI-Tracker/issues/3